### PR TITLE
Fix quick restart for StS2 v0.107.0

### DIFF
--- a/PauseMenuPatch.cs
+++ b/PauseMenuPatch.cs
@@ -1,7 +1,6 @@
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.addons.mega_text;
-using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Multiplayer.Game;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Nodes.Screens.PauseMenu;
@@ -27,18 +26,18 @@ public static class PauseMenuPatch
 
         try
         {
-            Control buttonContainer = __instance.GetNode<Control>("%ButtonContainer");
-            NPauseMenuButton saveAndQuitButton = buttonContainer.GetNode<NPauseMenuButton>("SaveAndQuit");
+            Control buttonContainer = __instance._buttonContainer;
+            NPauseMenuButton saveAndQuitButton = __instance._saveAndQuitButton;
 
             // Duplicate an existing button as our localized retry button
             NPauseMenuButton retryButton = (NPauseMenuButton)saveAndQuitButton.Duplicate();
             retryButton.Name = "Retry";
             MakeButtonVisualsUnique(retryButton);
             retryButton.GetNode<MegaLabel>("Label")
-                .SetTextAutoSize(new LocString("gameplay_ui", "QUICKRESTART2.pause_menu.retry").GetFormattedText());
+                .SetTextAutoSize(GetRetryButtonText());
 
             // Insert before GiveUp
-            NPauseMenuButton giveUpButton = buttonContainer.GetNode<NPauseMenuButton>("GiveUp");
+            NPauseMenuButton giveUpButton = __instance._giveUpButton;
             int giveUpIndex = giveUpButton.GetIndex();
             buttonContainer.AddChild(retryButton);
             buttonContainer.MoveChild(retryButton, giveUpIndex);
@@ -83,6 +82,12 @@ public static class PauseMenuPatch
         buttonImage.Material = (ShaderMaterial)material.Duplicate();
     }
 
+    private static string GetRetryButtonText()
+    {
+        string locale = TranslationServer.GetLocale();
+        return locale.StartsWith("zh", StringComparison.OrdinalIgnoreCase) ? "重试" : "Retry";
+    }
+
     private static void RebuildFocusNeighbors(Control buttonContainer)
     {
         List<NPauseMenuButton> buttons = [];
@@ -114,7 +119,7 @@ public static class SaveAndQuitDisablePatch
     public static void Prefix(NPauseMenu __instance)
     {
         // Disable all buttons in the container, including our Retry button
-        Control buttonContainer = __instance.GetNode<Control>("%ButtonContainer");
+        Control buttonContainer = __instance._buttonContainer;
         foreach (Node child in buttonContainer.GetChildren())
         {
             if (child is NPauseMenuButton btn)

--- a/QuickSaveLoad.cs
+++ b/QuickSaveLoad.cs
@@ -39,10 +39,10 @@ public static class QuickSaveLoad
 
             await NGame.Instance!.Transition.FadeOut();
 
-            RunManager.Instance.CleanUp();
+            RunManager.Instance.CleanUp(graceful: false);
 
             // 3. Reload from save (same flow as NMainMenu.OnContinueButtonPressedAsync)
-            await RunManager.Instance.SetUpSavedSinglePlayer(runState, serializableRun);
+            await RunManager.Instance.SetUpSavedSingleplayer(runState, serializableRun);
             NGame.Instance.ReactionContainer.InitializeNetworking(new NetSingleplayerGameService());
             await NGame.Instance.LoadRun(runState, serializableRun.PreFinishedRoom);
             await NGame.Instance.Transition.FadeIn();
@@ -55,4 +55,3 @@ public static class QuickSaveLoad
         }
     }
 }
-

--- a/QuickSaveLoad.cs
+++ b/QuickSaveLoad.cs
@@ -20,6 +20,7 @@ public static class QuickSaveLoad
 
     private static async Task QuickLoadAsync()
     {
+        bool fadedOut = false;
         try
         {
             // 1. Read the game's own autosave
@@ -38,8 +39,9 @@ public static class QuickSaveLoad
             NRunMusicController.Instance?.StopMusic();
 
             await NGame.Instance!.Transition.FadeOut();
+            fadedOut = true;
 
-            RunManager.Instance.CleanUp(graceful: false);
+            RunManager.Instance.CleanUp(graceful: true);
 
             // 3. Reload from save (same flow as NMainMenu.OnContinueButtonPressedAsync)
             await RunManager.Instance.SetUpSavedSingleplayer(runState, serializableRun);
@@ -52,6 +54,10 @@ public static class QuickSaveLoad
         catch (Exception ex)
         {
             MainFile.Logger.Error($"Quick Load failed: {ex}");
+            if (fadedOut)
+            {
+                await NGame.Instance!.Transition.FadeIn();
+            }
         }
     }
 }

--- a/quickRestart2.csproj
+++ b/quickRestart2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.5.1">
+<Project Sdk="Godot.NET.Sdk/4.5.1">
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>true</ImplicitUsings>
@@ -59,10 +59,10 @@
         </Reference>
         <Reference Include="sts2">
             <HintPath>$(Sts2DataDir)/sts2.dll</HintPath>
-            <Publicize>PublicizeSts</Publicize> <!--Allows private/protected field references but may cause errors.-->
+            <Publicize>True</Publicize> <!--Allows private/protected field references but may cause errors.-->
         </Reference>
         
-        <AdditionalFiles Include="ModTemplate\localization\**\*.json"/>
+        <AdditionalFiles Include="quickRestart2\localization\**\*.json"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/quickRestart2.json
+++ b/quickRestart2.json
@@ -4,7 +4,7 @@
   "author": "erasels, freude916, copilot, Anthropic Opus 4.6",
   "description": "quick save & load in Sts2",
   "version": "v0.1.2.99-archived",
-  "has_pck": true,
+  "has_pck": false,
   "has_dll": true,
   "dependencies": [
   ],


### PR DESCRIPTION
Fixes the v0.107.0 API changes for CleanUp and SetUpSavedSingleplayer, and removes the PCK requirement so the DLL-only mod loads correctly.